### PR TITLE
Fixed footer to appear on the bottom on all our current pages.

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,11 +1,14 @@
 /* Footer styles */
-.footer {
+footer {
     background-color: #222;
     color: #fff;
     padding: 20px 0;
     font-family: Arial, sans-serif;
     flex-shrink: 0; /* Prevents footer from shrinking */
     flex-wrap: wrap;
+    z-index: 1; /* Ensures footer is above other elements */
+    position: relative;
+    bottom: 0;
   }
   
   .footer-container {
@@ -14,6 +17,9 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 20px;
+    padding-bottom: 0;
+    margin-bottom: 0;
+
   }
   
   .footer-branding, .footer-links, .footer-social {
@@ -56,20 +62,3 @@
     font-size: 14px;
   }
   
-  /* Body and Layout for footer positioning */
-  body, html {
-    height: 100%; /* Ensure the body takes up full height */
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-  }
-  
-  #root {
-    display: flex;
-    flex-direction: column;
-    min-height: 100%; /* Ensures the app takes the full screen height */
-  }
-  
-  main {
-    flex: 1; /* Main content grows to take available space */
-  }

--- a/src/components/GroupDetails/DeleteGroupButton.css
+++ b/src/components/GroupDetails/DeleteGroupButton.css
@@ -1,5 +1,4 @@
 .delete-group-button {
-    position: absolute;
     bottom: 50%; 
     right: 10%; 
     background-color: red;
@@ -8,6 +7,8 @@
     border: none;
     border-radius: 5px;
     cursor: pointer;
+    z-index: 100;
+    position: absolute;
   }
   .delete-group-button:hover {
     background-color: darkred;

--- a/src/screens/GroupDetailsPage.css
+++ b/src/screens/GroupDetailsPage.css
@@ -1,0 +1,10 @@
+.container-groupdetails{
+    min-height:100vh;
+    display:flex;
+    flex: 1;
+
+}
+
+.content {
+    flex: 1; /* Push the footer to the bottom if content is short */
+  }

--- a/src/screens/GroupDetailsPage.js
+++ b/src/screens/GroupDetailsPage.js
@@ -2,14 +2,17 @@ import React from "react";
 import { GroupDetailsResults } from "../components/GroupDetails/GroupDetailsResults.js";
 import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
+import './GroupDetailsPage.css'
 const GroupDetailsPage = () => {
   
 
   return (
     <div>
-    <Navbar />
-    <GroupDetailsResults />
-    <Footer />
+      <Navbar />
+      <div className="container-groupdetails">
+        <GroupDetailsResults />
+      </div>
+      <Footer />
     </div>
   );
 };

--- a/src/screens/GroupPage.css
+++ b/src/screens/GroupPage.css
@@ -2,7 +2,7 @@
 .GroupPage {
     display: flex;
     flex-direction: column; /* Stack items vertically */
-    min-height: 100%; /* Ensure the entire screen height is covered */
+    min-height: 100vh; /* Ensure the entire screen height is covered */
   }
   
   .content {

--- a/src/screens/GroupPage.js
+++ b/src/screens/GroupPage.js
@@ -17,14 +17,16 @@ const GroupPage = () => {
   };
 
   return (
+    <div>
+    <Navbar />
     <GroupProvider>  {/* Wrap GroupPage with GroupProvider */}
       <div className="GroupPage">
-        <Navbar />
         <GroupList refresh={refresh} setRefresh={setRefresh} />
         <GroupCreation onGroupCreated={handleGroupCreated} />
       </div>
-      <Footer />
     </GroupProvider>
+    <Footer />
+    </div>
   );
 }
 

--- a/src/screens/Home.css
+++ b/src/screens/Home.css
@@ -1,7 +1,7 @@
 .Home {
     display: flex;
     flex-direction: column; /* Stack items vertically */
-    min-height: 100%; /* Ensure the entire screen height is covered */
+    min-height: 100vh; /* Ensure the entire screen height is covered */
   }
   
   .content {

--- a/src/screens/ProfilePage.css
+++ b/src/screens/ProfilePage.css
@@ -1,5 +1,5 @@
 .ProfilePage {
-    min-height: 100%; 
+    min-height: 100vh; 
     display: flex;
     flex-direction: column;
     

--- a/src/screens/ScreeningsPage.css
+++ b/src/screens/ScreeningsPage.css
@@ -1,7 +1,8 @@
-.screeningspage{
+.ScreeningsPage{
     display: flex;
     flex-direction: column; /* Stack items vertically */
-    min-height: 100%; /* Ensure the entire screen height is covered */
+    min-height: 100vh; /* Ensure the entire screen height is covered */
+    margin: 0;
 }
 
 .content {

--- a/src/screens/ScreeningsPage.js
+++ b/src/screens/ScreeningsPage.js
@@ -33,8 +33,9 @@ function ScreeningsPage() {
   };
 
   return (
+  <div>
+    <Navbar />
     <div className="ScreeningsPage">
-      <Navbar />
       <div className="content">
         <ScreeningResults />
       {showButton && (
@@ -43,8 +44,9 @@ function ScreeningsPage() {
         </button>
       )}
         </div>
-      <Footer />
     </div>
+  <Footer />
+  </div>
   );
 }
 


### PR DESCRIPTION
Footer is a relative component now, and it is on the bottom of the page. Made sure to use "min-height: 100vh;" on all main pages. This is good practise in future. Keep the content in its own containers and navbar should be on top of that container while footer should be on the bottom of it.

Examples can be visible on our current page files.